### PR TITLE
Fixed 2 flaky test

### DIFF
--- a/jaxb/src/test/java/com/fasterxml/jackson/module/jaxb/id/TestXmlID2.java
+++ b/jaxb/src/test/java/com/fasterxml/jackson/module/jaxb/id/TestXmlID2.java
@@ -9,7 +9,8 @@ import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.module.jaxb.BaseJaxbTest;
 import com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector;
-
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 public class TestXmlID2 extends BaseJaxbTest
 {
     @XmlRootElement(name = "department")
@@ -45,6 +46,7 @@ public class TestXmlID2 extends BaseJaxbTest
     
     @XmlRootElement(name = "user")
     @XmlAccessorType(XmlAccessType.FIELD)
+    @JsonPropertyOrder({ "id", "username","email","department" })
     static class User
     {
         @XmlElement @XmlID
@@ -120,13 +122,15 @@ public class TestXmlID2 extends BaseJaxbTest
         // true -> ignore XmlIDREF annotation
                 .annotationIntrospector(new JaxbAnnotationIntrospector(true))
                 .build();
-        
+
         // first, with default settings (first NOT as id)
         List<User> users = getUserList();
         String json = mapper.writeValueAsString(users);
+        
         assertEquals(expected, json);
     
         List<User> result = mapper.readValue(json, new TypeReference<List<User>>() { });
+
         assertEquals(3, result.size());
         assertEquals(Long.valueOf(11), result.get(0).id);
         assertEquals(Long.valueOf(22), result.get(1).id);
@@ -135,10 +139,8 @@ public class TestXmlID2 extends BaseJaxbTest
     
     public void testIdWithJaxbRules() throws Exception
     {
-        ObjectMapper mapper = JsonMapper.builder()
-        // but then also variant where ID is ALWAYS used for XmlID / XmlIDREF
-                .annotationIntrospector(new JaxbAnnotationIntrospector())
-                .build();
+        ObjectMapper mapper = newObjectMapper();
+
         List<User> users = getUserList();
         final String json = mapper.writeValueAsString(users);
         String expected = "[{\"id\":11,\"username\":\"11\",\"email\":\"11@test.com\",\"department\":9}"


### PR DESCRIPTION
* There are two test fixed:
1. com.fasterxml.jackson.module.jaxb.id.TestXmlID2#testIdWithJaxbRules
2. com.fasterxml.jackson.module.jaxb.id.TestXmlID2#testIdWithJacksonRules 

The test `TesTxMLLd2#testIdWithJaxbRules` and `TestXmlID2#testIdWithJacksonRules`  compares the result created by `writeValueAsString()` with a hardcoded string. It turns out the the string returned by `writeValueAsString()` is not a deterministic string. The reason is that the type of argument taken by `writeValueAsString() `ObjectMapper. JSON serialization is not required to be deterministic. The solution I've chosen to fix this is to get rid of `JsonMapper.builder() `when creating a new instance, I change the funtion to `newObjectMapper()`. According to Jackson Annotation Documentation, in this case, we can add keywords `@JsonPropertyOrder({ "id", "username","email","department" })` before defining the class User. Thus the properties order will be fixed. 

This PR helps to guarantee the order of the string returned by writeValueAsString() and make it dererministic.